### PR TITLE
Switches to fabricatr for simulating data

### DIFF
--- a/docs/modelling.qmd
+++ b/docs/modelling.qmd
@@ -10,6 +10,7 @@ bibliography: references.bib
 #| output: false
 library(tidyverse)
 library(tidymodels)
+library(vip)
 tidymodels_prefer()
 ```
 
@@ -171,10 +172,10 @@ zero.
 Whilst we have defined the relationship between variables in the Worfklow above we now need to say what model we wish to
 use to test the relationship between variables.
 
-We first set up a simple logistic regression model using [parsnip](https://parsnip.tidymodels.org/). The `mixture` argument is a value `0 <= mixture <= 1`
-which determines how much L1 regularisation is used in the model. A value of `mixture = 1` is equivalent to full L1
-regularisation and a LASSO model whilst a value of `mixture = 0` is equivalent to full L2 regularisation and ridge
-regression.
+We first set up a simple logistic regression model using [parsnip](https://parsnip.tidymodels.org/). The `mixture`
+argument is a value `0 <= mixture <= 1` which determines how much L1 regularisation is used in the model. A value of
+`mixture = 1` is equivalent to full L1 regularisation and a LASSO model whilst a value of `mixture = 0` is equivalent to
+full L2 regularisation and ridge regression.
 
 ```{r}
 #| label: lasso-specification
@@ -224,7 +225,7 @@ lasso_kfold_roc_auc <- lasso_grid |>
 #| eval: false
 #| echo: true
 #| output: false
-final_lasso_kfold <- workflows::finalize_workflow(
+final_lasso_kfold <- tune::finalize_workflow(
   workflows::add_model(thyroid_workflow, tune_spec_lasso),
   lasso_kfold_roc_auc
 )

--- a/docs/modelling.qmd
+++ b/docs/modelling.qmd
@@ -64,7 +64,7 @@ the data, often a slightly larger proportion is used for the training subset, he
 #| echo: true
 #| output: false
 set.seed(5039378)
-split <- rsample::initial_split(df_dummy, prop = 0.75)
+split <- rsample::initial_split(dummy, prop = 0.75)
 train <- rsample::training(split)
 test <- rsample::testing(split)
 ```
@@ -122,9 +122,9 @@ what model is being fitted. Steps that can go into making a recipe are...
 #| eval: true
 #| echo: true
 #| output: false
-thyroid_recipe <- recipes::recipe(final_pathology_dummy ~ dummy_cat_1 + dummy_cat_2 + V1, data = train) |>
-  recipes::step_num2factor(final_pathology_dummy, levels = c("Benign", "Malignant")) |>
-  recipes::step_dummy(dummy_cat_1, dummy_cat_2) |>
+thyroid_recipe <- recipes::recipe(final_pathology ~ gender + nodule_size + age + asa_score + smoking_status + nodule_fna_thy, data = train) |>
+  recipes::step_num2factor(final_pathology, levels = c("Benign", "Malignant")) |>
+  recipes::step_dummy(gender, asa_score, smoking_status, nodule_fna_thy) |>
   recipes::step_normalize(all_numeric())
 ```
 
@@ -171,10 +171,10 @@ zero.
 Whilst we have defined the relationship between variables in the Worfklow above we now need to say what model we wish to
 use to test the relationship between variables.
 
-We first set up a simple logistic regression model using [parsnip](https://parsnip.tidymodels.org/). The `mixture`
-argument is a value `0 <= mixture <= 1` which determines how much L1 regularisation is used in the model. A value of
-`mixture = 1` is equivalent to full L1 regularisation and a LASSO model whilst a value of `mixture = 0` is equivalent to
-ridge regression.
+We first set up a simple logistic regression model using [parsnip](https://parsnip.tidymodels.org/). The `mixture` argument is a value `0 <= mixture <= 1`
+which determines how much L1 regularisation is used in the model. A value of `mixture = 1` is equivalent to full L1
+regularisation and a LASSO model whilst a value of `mixture = 0` is equivalent to full L2 regularisation and ridge
+regression.
 
 ```{r}
 #| label: lasso-specification

--- a/r/master.R
+++ b/r/master.R
@@ -6,6 +6,7 @@ library(Hmisc)
 library(lubridate)
 library(tidymodels)
 library(tidyverse)
+library(vip)
 
 ## Set directories based on current location
 base_dir <- getwd()

--- a/r/simulate_data.R
+++ b/r/simulate_data.R
@@ -65,7 +65,22 @@ dummy <- fabricatr::fabricate(
     break_labels = c("Thy1", "Thy2", "Thy3", "Thy4", "Thy5")
   )
 ) |>
-  dplyr::select(!c(pathology, sex, asa, smoker, nodule_fna))
+  dplyr::select(!c(pathology, sex, asa, smoker, nodule_fna)) |>
+  ## Convert variables to factors
+  dplyr::mutate(
+    final_pathology = case_match(
+      final_pathology,
+      0 ~ "Benign",
+      1 ~ "Malignant"
+    ),
+    final_pathology = as.factor(final_pathology),
+    gender = case_match(
+      gender,
+      0 ~ "Male",
+      1 ~ "Female"
+    ),
+    gender = as.factor(gender)
+  )
 
 var_labels <- c(
   ID = "ID",

--- a/r/simulate_data.R
+++ b/r/simulate_data.R
@@ -1,7 +1,7 @@
 ## Filename : simulate_data.R
 ## Description : Generates dummy variables for the purpose of demonstrating modelling workflow
 ##
-## The code here was guided by the article https://www.r-bloggers.com/2021/05/how-to-generate-correlated-data-in-r/
+## Uses the fabricatr package https://declaredesign.org/r/fabricatr/index.html
 
 
 
@@ -9,10 +9,7 @@
 library(MASS)
 library(tidyverse)
 library(tidymodels)
-library(ggdark)
-library(knitr)
-library(tidyr)
-
+library(fabricatr)
 ## Two options we can either source the cleaning file...
 # source("r/master.R")
 ## Or we can load the file that is saved at the end and use that
@@ -21,82 +18,65 @@ df <- readRDS("data/r/clean.rds")
 ## Set a seed for random number generation. This ensures we get the same results each time the code is run.
 set.seed(17010880)
 
-## Create a varianc co-variance matrix
-sigma <- rbind(
-  c(1.1265924, 0.6387496, -0.2630270, 0.2875068),
-  c(0.6387496, 1.2053968, 0.8055271, -0.2540865),
-  c(0.2630270, 0.8055271, 1.1482047, -0.4735176),
-  c(0.2875068, -0.2540865, -0.4735176, 1.0012329)
-)
-det(sigma)
+## Set parameters
+n_obs <- nrow(df)
+gender_ratio <- 0.5
+nodule_diameter_mean <- 24.82
+nodule_diameter_sd <- 14.94
+age_mean <- 54.37
+age_sd <- 16.65
+asa_score_boundary <- c(-Inf, -2, 6, 12, Inf)
+smoking_boundary <- c(-Inf, 0, 1, Inf)
+nodule_fna_thy_boundary <- c(-Inf, -4, 1, 6, 11, Inf)
+scaling <- 5
 
-## Generate the mean vector
-mu <- c(44, 10, 6, 3)
-
-## Generate the multivariate normal distribution
-dummy <- as.data.frame(MASS::mvrnorm(n = nrow(df), mu = mu, Sigma = sigma))
-
-## Generate binary outcome variable with noise
-dummy <- dummy |>
-  mutate(
-    final_pathology_dummy = ifelse(V4 > median(V4),
-      sample(c(0, 1), n(), replace = TRUE, p = c(0.25, 0.75)),
-      sample(c(0, 1), n(), replace = TRUE, p = c(0.75, 0.25))
-    ),
-    ## final_pathology_dummy = case_when(
-    ##   V4 <= median(V4) ~ sample(c("Bengin", "Malignant"),
-    ##     n(),
-    ##     replace = TRUE,
-    ##     p = c(0.25, 0.75)),
-    ##   TRUE ~ sample(c("Bengin", "Malignant"),
-    ##     n(),
-    ##     replace = TRUE,
-    ##     p = c(0.75, 0.25))),
-    dummy_cat_1 = case_when(
-      V3 < quantile(V3, 0.25) ~ sample(c("a", "b", "c", "d"),
-        n(),
-        replace = TRUE,
-        p = c(0.7, 0.1, 0.1, 0.1)
-      ),
-      V3 < quantile(V3, 0.50) ~ sample(c("a", "b", "c", "d"),
-        n(),
-        replace = TRUE,
-        p = c(0.1, 0.7, 0.1, 0.1)
-      ),
-      V3 < quantile(V3, 0.75) ~ sample(c("a", "b", "c", "d"),
-        n(),
-        replace = TRUE,
-        p = c(0.1, 0.1, 0.7, 0.1)
-      ),
-      TRUE ~ sample(c("a", "b", "c", "d"),
-        n(),
-        replace = TRUE,
-        p = c(0.1, 0.1, 0.7, 0.1)
-      )
-    ),
-    dummy_cat_2 = case_when(
-      V2 < quantile(V2, 0.15) ~ sample(c("I", "II", "III", "IV"),
-        n(),
-        replace = TRUE,
-        p = c(0.8, 0.1, 0.05, 0.05)
-      ),
-      V2 < quantile(V2, 0.65) ~ sample(c("I", "II", "III", "IV"),
-        n(),
-        replace = TRUE,
-        p = c(0.1, 0.8, 0.05, 0.05)
-      ),
-      V2 < quantile(V2, 0.85) ~ sample(c("I", "II", "III", "IV"),
-        n(),
-        replace = TRUE,
-        p = c(0.1, 0.05, 0.8, 0.05)
-      ),
-      TRUE ~ sample(c("I", "II", "III", "IV"),
-        n(),
-        replace = TRUE,
-        p = c(0.1, 0.05, 0.05, 0.8)
-      )
-    )
+dummy <- fabricatr::fabricate(
+  N = n_obs,
+  pathology = runif(n_obs),
+  final_pathology = draw_binary(latent = pathology, link = "probit"),
+  sex = runif(n_obs),
+  gender = draw_binary(prob = gender_ratio, N = n_obs),
+  ## asa_score = draw_ordered(),
+  ## smoking_status = draw_ordered(),
+  nodule_size = rnorm(n_obs,
+    mean = nodule_diameter_mean,
+    sd = nodule_diameter_sd
+  ),
+  age = round(rnorm(n_obs,
+    mean = age_mean,
+    sd = age_sd
+  )),
+  asa = scaling * rnorm(n_obs),
+  asa_score = draw_ordered(
+    x = asa,
+    breaks = asa_score_boundary,
+    break_labels = c("I", "II", "III", "IV")
+  ),
+  smoker = rnorm(n_obs),
+  smoking_status = draw_ordered(
+    x = smoker,
+    breaks = smoking_boundary,
+    break_labels = c("Non-Smoker", "Ex-smoker", "Current")
+  ),
+  nodule_fna = scaling * rnorm(n_obs),
+  nodule_fna_thy = draw_ordered(
+    x = nodule_fna,
+    breaks = nodule_fna_thy_boundary,
+    break_labels = c("Thy1", "Thy2", "Thy3", "Thy4", "Thy5")
   )
-GGally::ggpairs(dummy)
+) |>
+  dplyr::select(!c(pathology, sex, asa, smoker, nodule_fna))
+
+var_labels <- c(
+  ID = "ID",
+  final_pathology = "Malignancy status",
+  gender = "Gender",
+  nodule_size = "Nodule Size (mm)",
+  age = "Age (Years)",
+  asa_score = "ASA Score",
+  smoking_status = "Smoking Status",
+  nodule_fna_thy = "FNA Thy Status"
+)
+Hmisc::label(dummy) <- as.list(var_labels[match(names(dummy), names(var_labels))])
 
 df_dummy <- cbind(df, dummy)

--- a/renv.lock
+++ b/renv.lock
@@ -41,31 +41,6 @@
       ],
       "Hash": "7a29697b75e027767a53fde6c903eca7"
     },
-    "GGally": {
-      "Package": "GGally",
-      "Version": "2.2.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "RColorBrewer",
-        "dplyr",
-        "ggplot2",
-        "ggstats",
-        "grDevices",
-        "grid",
-        "gtable",
-        "lifecycle",
-        "magrittr",
-        "plyr",
-        "progress",
-        "rlang",
-        "scales",
-        "tidyr",
-        "utils"
-      ],
-      "Hash": "5da89b9b10d98a7820adb426939900a7"
-    },
     "GPfit": {
       "Package": "GPfit",
       "Version": "1.0-8",
@@ -287,27 +262,6 @@
         "tidyr"
       ],
       "Hash": "fd25391c3c4f6ecf0fa95f1e6d15378c"
-    },
-    "broom.helpers": {
-      "Package": "broom.helpers",
-      "Version": "1.14.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "broom",
-        "cli",
-        "dplyr",
-        "labelled",
-        "lifecycle",
-        "purrr",
-        "rlang",
-        "stats",
-        "stringr",
-        "tibble",
-        "tidyr"
-      ],
-      "Hash": "ea30eb5d9412a4a5c2740685f680cd49"
     },
     "bslib": {
       "Package": "bslib",
@@ -662,6 +616,17 @@
       ],
       "Hash": "daf4a1246be12c1fa8c7705a0935c1a0"
     },
+    "fabricatr": {
+      "Package": "fabricatr",
+      "Version": "1.0.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "rlang"
+      ],
+      "Hash": "b129f5ea87fe414655101292ed77f71a"
+    },
     "fansi": {
       "Package": "fansi",
       "Version": "1.0.6",
@@ -866,29 +831,6 @@
         "withr"
       ],
       "Hash": "313d31eff2274ecf4c1d3581db7241f9"
-    },
-    "ggstats": {
-      "Package": "ggstats",
-      "Version": "0.5.1",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "broom.helpers",
-        "cli",
-        "dplyr",
-        "forcats",
-        "ggplot2",
-        "lifecycle",
-        "magrittr",
-        "patchwork",
-        "purrr",
-        "rlang",
-        "scales",
-        "stats",
-        "stringr",
-        "tidyr"
-      ],
-      "Hash": "006a64911e79a7dc7cbf839a57baaff4"
     },
     "glmnet": {
       "Package": "glmnet",
@@ -1265,23 +1207,6 @@
       ],
       "Hash": "b64ec208ac5bc1852b285f665d6368b3"
     },
-    "labelled": {
-      "Package": "labelled",
-      "Version": "2.12.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "dplyr",
-        "haven",
-        "lifecycle",
-        "rlang",
-        "stringr",
-        "tidyr",
-        "vctrs"
-      ],
-      "Hash": "1ec27c624ece6c20431e9249bd232797"
-    },
     "lattice": {
       "Package": "lattice",
       "Version": "0.22-5",
@@ -1600,17 +1525,6 @@
         "utils"
       ],
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
-    },
-    "plyr": {
-      "Package": "plyr",
-      "Version": "1.8.9",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "Rcpp"
-      ],
-      "Hash": "6b8177fd19982f0020743fadbfdbd933"
     },
     "prettyunits": {
       "Package": "prettyunits",


### PR DESCRIPTION
Closes #30

Switches to using `fabricatr` to simulate data and updates `docs/modelling.qmd` in light of this.

Still have errors in `docs/modelling.qmd` though when attempting to tune the LASSO model the cross-validation fails as the size of the subset generated differs from the existing data. Confusing as we split data into `train` and `test` first and set the `recipe` up with just the `train` subset.